### PR TITLE
Fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - Type ```npm install``` into the command line to install the necessary dependencies
 - Type in ```npm start``` into the command line to run the server. This will run on ```http://localhost:3002/``` in your browser.
 - To view the data that your server currently is holding, you can view it at ```http://localhost:3002/api/v1/favoritesList``` *note that if this is your first time running the repo, you will only see an empty array.
-- Now that you have your local server up and running, you can return to the [Rancid Tomatillos](www.github.com/stephaniemagdic/rancid-tomatillos) directory to finish the apps setup instructions!
+- Now that you have your local server up and running, you can return to the [Rancid Tomatillos](https://github.com/stephaniemagdic/rancid-tomatillos) directory to finish the apps setup instructions!
 
 ## Authors
 [Stephanie Magdic](www.github.com/stephaniemagdic) & [Mark Cawthray](www.github.com/MTCawthray)


### PR DESCRIPTION
This fixes the link to our main Rancid Tomatillos repo in the readme setup instructions